### PR TITLE
Fix Tailwind content path

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   content: [
-    './index.html',
+    './src/index.html',
     './src/**/*.{js,ts,jsx,tsx}'
   ],
   darkMode: 'class',


### PR DESCRIPTION
## Summary
- update Tailwind config so it looks at `src/index.html`

## Testing
- `npm run build-renderer` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684917f3a078832b97276af496d15bdf