### PR TITLE
Add hidden startup for BrowserWindow

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -14,6 +14,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1000,
     height: 700,
+    show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true


### PR DESCRIPTION
## Summary
- ensure main window stays hidden until it's ready

## Testing
- `npm run build-main` *(fails: Cannot find module 'fs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684917f2fc84832b85908a1b11842c8e