### PR TITLE
Refactor autosave path resolution

### DIFF
--- a/fileUtils.ts
+++ b/fileUtils.ts
@@ -2,20 +2,28 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { app } from 'electron';
 
-const userDir = app.getPath('userData');
-const autosavePath = path.join(userDir, 'autosave.md');
-const recentPath = path.join(userDir, 'recent.json');
+function getUserDir(): string {
+  return app.getPath('userData');
+}
+
+function getAutosavePath(): string {
+  return path.join(getUserDir(), 'autosave.md');
+}
+
+function getRecentPath(): string {
+  return path.join(getUserDir(), 'recent.json');
+}
 
 export async function readAutosave(): Promise<string> {
   try {
-    return await fs.readFile(autosavePath, 'utf-8');
+    return await fs.readFile(getAutosavePath(), 'utf-8');
   } catch {
     return '';
   }
 }
 
 export async function saveAutosave(content: string): Promise<void> {
-  await fs.writeFile(autosavePath, content, 'utf-8');
+  await fs.writeFile(getAutosavePath(), content, 'utf-8');
 }
 
 export async function readFileContent(filePath: string): Promise<string> {
@@ -24,7 +32,7 @@ export async function readFileContent(filePath: string): Promise<string> {
 
 export async function getRecent(): Promise<string[]> {
   try {
-    const data = await fs.readFile(recentPath, 'utf-8');
+    const data = await fs.readFile(getRecentPath(), 'utf-8');
     return JSON.parse(data);
   } catch {
     return [];
@@ -37,5 +45,5 @@ export async function addRecent(filePath: string): Promise<void> {
   if (index !== -1) recents.splice(index, 1);
   recents.unshift(filePath);
   if (recents.length > 10) recents.pop();
-  await fs.writeFile(recentPath, JSON.stringify(recents), 'utf-8');
+  await fs.writeFile(getRecentPath(), JSON.stringify(recents), 'utf-8');
 }


### PR DESCRIPTION
## Summary
- remove cached autosave and recent file paths
- add helper functions that compute user data paths when needed
- update path usage in file utilities

## Testing
- `npm run build-main` *(fails: Cannot find module 'fs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684917f1d430832bb7727007990f2d4c