### PR TITLE
Enhance editor UX with save support and theme persistence

### DIFF
--- a/fileUtils.ts
+++ b/fileUtils.ts
@@ -23,11 +23,27 @@ export async function readAutosave(): Promise<string> {
 }
 
 export async function saveAutosave(content: string): Promise<void> {
-  await fs.writeFile(getAutosavePath(), content, 'utf-8');
+  try {
+    await fs.writeFile(getAutosavePath(), content, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to save autosave: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 export async function readFileContent(filePath: string): Promise<string> {
-  return fs.readFile(filePath, 'utf-8');
+  try {
+    return await fs.readFile(filePath, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to read file: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export async function saveFileContent(filePath: string, content: string): Promise<void> {
+  try {
+    await fs.writeFile(filePath, content, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to write file: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 export async function getRecent(): Promise<string[]> {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.3",
-    "remark-gfm": "^3.0.1"
+    "remark-gfm": "^3.0.1",
+    "remark-prism": "^1.3.0",
+    "prismjs": "^1.29.0"
   }
 }

--- a/preload.ts
+++ b/preload.ts
@@ -4,5 +4,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   readAutosave: () => ipcRenderer.invoke('read-autosave'),
   saveAutosave: (content: string) => ipcRenderer.invoke('save-autosave', content),
   openFile: () => ipcRenderer.invoke('open-file'),
-  getRecent: () => ipcRenderer.invoke('get-recent')
+  getRecent: () => ipcRenderer.invoke('get-recent'),
+  saveFile: (content: string, filePath?: string) => ipcRenderer.invoke('save-file', { filePath, content }),
+  readFile: (filePath: string) => ipcRenderer.invoke('read-file', filePath)
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import 'prismjs/themes/prism.css';


### PR DESCRIPTION
## Summary
- add error handling helpers for file operations
- expose save and read helpers in the Electron main & preload layers
- allow saving/opening specific files from the UI
- remember theme choice between sessions
- include optional code highlighting with remark-prism
- display recent files as clickable links

## Testing
- `npm run build-main` *(fails: Cannot find module 'electron' or its type declarations)*
- `npm run build-renderer` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492da4685c832ba4eff7b800d20ca8