### PR TITLE
Add Markdown file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ npm run build
 - Recent file tracking
 - Light/Dark theme toggle
 - Splash screen on startup
+- Upload `.md` files via drag-and-drop or by clicking the upload area in the editor panel
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ const App: React.FC = () => {
   const [theme, setTheme] = useState<'light' | 'dark'>(prefersDark ? 'dark' : 'light');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
+  const dragCounter = useRef(0);
 
   useEffect(() => {
     const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
@@ -126,26 +127,38 @@ const App: React.FC = () => {
     if (!file.name.endsWith('.md')) return;
     const reader = new FileReader();
     reader.onload = e => {
-      const text = e.target?.result as string;
-      if (text !== undefined) setMarkdown(text);
+      const text = e.target?.result;
+      if (typeof text === 'string') {
+        setMarkdown(text);
+        setCurrentPath(undefined);
+      }
     };
     reader.readAsText(file);
   };
 
   const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+    dragCounter.current = 0;
     setDragging(false);
     handleFiles(e.dataTransfer.files);
   };
 
   const onDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+  };
+
+  const onDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    dragCounter.current++;
     setDragging(true);
   };
 
   const onDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
-    setDragging(false);
+    dragCounter.current--;
+    if (dragCounter.current === 0) {
+      setDragging(false);
+    }
   };
 
   const openRecent = async (p: string) => {
@@ -215,6 +228,7 @@ const App: React.FC = () => {
             onClick={() => fileInputRef.current?.click()}
             onDrop={onDrop}
             onDragOver={onDragOver}
+            onDragEnter={onDragEnter}
             onDragLeave={onDragLeave}
             className={`drop-zone ${dragging ? 'dragging' : ''}`}
           >

--- a/src/index.css
+++ b/src/index.css
@@ -2,3 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 @import 'prismjs/themes/prism.css';
+
+.drop-zone {
+  @apply border-2 border-dashed rounded-lg cursor-pointer text-center text-sm p-4 text-gray-600 dark:text-gray-300 mb-2;
+}
+
+.drop-zone.dragging {
+  @apply border-blue-500 bg-blue-50 dark:bg-gray-700;
+}


### PR DESCRIPTION
## Summary
- add drag-and-drop upload support in the editor panel
- style the upload drop zone
- document file upload feature

## Testing
- `npm run build-renderer` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684938854dac832bb79b966c599cb159