### PR TITLE
Add drag-and-drop open support and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ npm run build
 - Light/Dark theme toggle
 - Splash screen on startup
 
+## Opening Markdown Files
+
+1. Click the **Open File** button in the header and choose any `.md` file.
+2. Alternatively, drag and drop a Markdown file onto the window to open it.
+
+The editor automatically saves your work and keeps a list of recent files for quick access.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,8 +127,25 @@ const App: React.FC = () => {
     }
   };
 
+  const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file && file.path.endsWith('.md')) {
+      const result = await electronAPI.readFile(file.path);
+      if (result) {
+        setMarkdown(result.content);
+        setCurrentPath(result.path);
+        setRecent(await electronAPI.getRecent());
+      }
+    }
+  };
+
   return (
-    <div className="h-screen flex flex-col bg-gradient-to-br from-blue-50 via-white to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 transition-colors duration-300">
+    <div
+      className="h-screen flex flex-col bg-gradient-to-br from-blue-50 via-white to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 transition-colors duration-300"
+      onDragOver={e => e.preventDefault()}
+      onDrop={handleDrop}
+    >
       {/* Header */}
       <header className="flex items-center gap-3 px-6 py-3 border-b bg-white/80 dark:bg-gray-900/80 shadow-sm sticky top-0 z-10">
         <AppIcon />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,7 @@ const App: React.FC = () => {
   const handleDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const file = e.dataTransfer.files[0];
-    if (file && file.path.endsWith('.md')) {
+    if (file && file.path && file.path.toLowerCase().endsWith('.md')) {
       const result = await electronAPI.readFile(file.path);
       if (result) {
         setMarkdown(result.content);


### PR DESCRIPTION
## Summary
- enable drag-and-drop of `.md` files to open them in the editor
- document how to open files via button and drag-and-drop

## Testing
- `npm run build-main` *(fails: Cannot find module 'fs')*

------
https://chatgpt.com/codex/tasks/task_e_68493886a3e4832ba2dbb6104102f619